### PR TITLE
Add basic tests and CI

### DIFF
--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -1,0 +1,28 @@
+name: CI
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version: ["3.10"]
+    steps:
+      - uses: actions/checkout@v3
+      - name: Set up Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: ${{ matrix.python-version }}
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r requirements.txt
+      - name: Lint
+        run: flake8 .
+      - name: Test
+        run: pytest -v

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,5 @@ numpy
 pandas
 matplotlib
 scipy
+pytest
+flake8

--- a/tests/test_calcium_decay.py
+++ b/tests/test_calcium_decay.py
@@ -1,0 +1,47 @@
+import numpy as np
+import pandas as pd
+import tempfile
+import os
+import sys
+
+sys.path.append(os.path.dirname(os.path.dirname(__file__)))
+
+from calcium_decay_analysis import fit_one_phase_decay, calculate_zscores
+from preprocess import subset_fluorescence
+
+
+def test_fit_one_phase_decay_shapes():
+    time = np.linspace(0, 10, 50)
+    # create decaying signals for 3 cells
+    data = np.exp(-0.3 * time)[:, None] * np.ones((1, 3))
+    noise = 0.01 * np.random.randn(*data.shape)
+    raw = data + noise
+    params, fitted = fit_one_phase_decay(time, raw)
+    assert params.shape == (3, 3)
+    assert fitted.shape == raw.shape
+
+
+def test_calculate_zscores_shape():
+    corrected = np.random.rand(100, 4)
+    z = calculate_zscores(corrected, puff_idx=50, fs=5.0)
+    assert z.shape == corrected.shape
+    assert not np.isnan(z).any()
+
+
+def test_subset_fluorescence_shape():
+    # create fake dataframe with puff index and 2000 samples
+    n_cells = 3
+    puff_index = 1000
+    values = {}
+    for i in range(n_cells):
+        series = pd.Series([puff_index] + list(np.arange(1, 2001)))
+        values[i] = series
+    df = pd.DataFrame(values)
+    with tempfile.TemporaryDirectory() as tmpdir:
+        input_path = f"{tmpdir}/raw.csv"
+        output_path = f"{tmpdir}/subset.csv"
+        df.to_csv(input_path, index=False, header=False)
+        subset_fluorescence(input_path, output_path)
+        subset = pd.read_csv(output_path, header=None)
+    assert subset.shape == (1101, n_cells)
+    assert (subset.iloc[0] == 501).all()


### PR DESCRIPTION
## Summary
- add automated tests for decay fitting, z-score calculation and preprocessing
- run pytest and flake8 via GitHub Actions
- include pytest and flake8 in project requirements

## Testing
- `flake8 .`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685f4554c91c8329aa84b9aaffb16bb5